### PR TITLE
Use NumPy 1.13 legacy print mode in doctests

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -11,5 +11,5 @@ dependencies:
   - python-coveralls==2.5.0
 
   # Requirements
-  - numpy==1.11.3
-  - mahotas==1.4.3
+  - numpy==1.15.4
+  - mahotas==1.4.4

--- a/imgroi/core.py
+++ b/imgroi/core.py
@@ -24,6 +24,8 @@ def label_mask_stack(new_masks, dtype=None):
 
         Examples:
 
+            >>> numpy.set_printoptions(legacy="1.13")
+
             >>> label_mask_stack(
             ...     numpy.array([[[1, 0, 0, 0],
             ...                   [0, 0, 0, 0],
@@ -88,6 +90,8 @@ def find_contours(img):
             (numpy.ndarray):                   an array with contours.
 
         Examples:
+
+            >>> numpy.set_printoptions(legacy="1.13")
 
             >>> a = numpy.array([[ True,  True, False],
             ...                  [False, False, False],


### PR DESCRIPTION
Fixes https://github.com/jakirkham/imgroi/issues/9

To keep the doctests consistent over time, use the NumPy 1.13 legacy print mode. Should keep the maintenance effort of doctests to a minimum.